### PR TITLE
fix(schemas): missing enum types

### DIFF
--- a/s2-json-schema/schemas/Commodity.schema.json
+++ b/s2-json-schema/schemas/Commodity.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/Commodity.schema.json",
     "title": "Commodity",
+    "type": "string",
     "enum": ["GAS", "HEAT", "ELECTRICITY", "OIL"],
     "description": "GAS: Identifier for Commodity GAS\nHEAT: Identifier for Commodity HEAT\nELECTRICITY: Identifier for Commodity ELECTRICITY\nOIL: Identifier for Commodity OIL"
 }

--- a/s2-json-schema/schemas/CommodityQuantity.schema.json
+++ b/s2-json-schema/schemas/CommodityQuantity.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/CommodityQuantity.schema.json",
     "title": "CommodityQuantity",
+    "type": "string",
     "enum": ["ELECTRIC.POWER.L1", "ELECTRIC.POWER.L2", "ELECTRIC.POWER.L3", "ELECTRIC.POWER.3_PHASE_SYMMETRIC", "NATURAL_GAS.FLOW_RATE", "HYDROGEN.FLOW_RATE", "HEAT.TEMPERATURE", "HEAT.FLOW_RATE", "HEAT.THERMAL_POWER", "OIL.FLOW_RATE"],
     "description": "ELECTRIC.POWER.L1: Electric power described in Watt on phase 1. If a device utilizes only one phase it should always use L1.\nELECTRIC.POWER.L2: Electric power described in Watt on phase 2. Only applicable for 3 phase devices.\nELECTRIC.POWER.L3: Electric power described in Watt on phase 3. Only applicable for 3 phase devices.\nELECTRIC.POWER.3_PHASE_SYMMETRIC: Electric power described in Watt on when power is equally shared among the three phases. Only applicable for 3 phase devices.\nNATURAL_GAS.FLOW_RATE: Gas flow rate described in liters per second\nHYDROGEN.FLOW_RATE: Gas flow rate described in grams per second\nHEAT.TEMPERATURE: Heat described in degrees Celsius\nHEAT.FLOW_RATE: Flow rate of heat carrying gas or liquid in liters per second\nHEAT.THERMAL_POWER: Thermal power in Watt\nOIL.FLOW_RATE: Oil flow rate described in liters per hour"
 }

--- a/s2-json-schema/schemas/ControlType.schema.json
+++ b/s2-json-schema/schemas/ControlType.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/ControlType.schema.json",
     "title": "ControlType",
+    "type": "string",
     "enum": ["POWER_ENVELOPE_BASED_CONTROL", "POWER_PROFILE_BASED_CONTROL", "OPERATION_MODE_BASED_CONTROL", "FILL_RATE_BASED_CONTROL", "DEMAND_DRIVEN_BASED_CONTROL", "NOT_CONTROLABLE", "NO_SELECTION"],
     "description": "POWER_ENVELOPE_BASED_CONTROL: Identifier for the Power Envelope Based Control type\nPOWER_PROFILE_BASED_CONTROL: Identifier for the Power Profile Based Control type\nOPERATION_MODE_BASED_CONTROL: Identifier for the Operation Mode Based Control type\nFILL_RATE_BASED_CONTROL: Identifier for the Demand Driven Based Control type\nDEMAND_DRIVEN_BASED_CONTROL: Identifier for the Fill Rate Based Control type\nNOT_CONTROLABLE: Identifier that is to be used if no control is possible. Resources of this type can still provide measurements and forecast\nNO_SELECTION: Identifier that is to be used if no control type is or has been selected. "
 }

--- a/s2-json-schema/schemas/EnergyManagementRole.schema.json
+++ b/s2-json-schema/schemas/EnergyManagementRole.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/EnergyManagementRole.schema.json",
     "title": "EnergyManagementRole",
+    "type": "string",
     "enum": ["CEM", "RM"],
     "description": "CEM: Customer Energy Manager\nRM: Resource Manager"
 }

--- a/s2-json-schema/schemas/InstructionStatus.schema.json
+++ b/s2-json-schema/schemas/InstructionStatus.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/InstructionStatus.schema.json",
     "title": "InstructionStatus",
+    "type": "string",
     "enum": ["NEW", "ACCEPTED", "REJECTED", "REVOKED", "STARTED", "SUCCEEDED", "ABORTED"],
     "description": "NEW: Instruction was newly created\nACCEPTED: Instruction has been accepted\nREJECTED: Instruction was rejected\nREVOKED: Instruction was revoked\nSTARTED: Instruction was executed\nSUCCEEDED: Instruction finished successfully\nABORTED: Instruction was aborted."
 }

--- a/s2-json-schema/schemas/PEBC.PowerEnvelopeConsequenceType.schema.json
+++ b/s2-json-schema/schemas/PEBC.PowerEnvelopeConsequenceType.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/PEBC.PowerEnvelopeConsequenceType.schema.json",
     "title": "PEBC_PowerEnvelopeConsequenceType",
+    "type": "string",
     "enum": ["VANISH", "DEFER"],
     "description": "VANISH: Indicating that the limited load or generated will be lost and not reappear in the future (see Clause 7.6.2)\nDEFER: Indicating that the limited load or generation will be postponed to a later moment (see Clause 7.6.2)"
 }

--- a/s2-json-schema/schemas/PEBC.PowerEnvelopeLimitType.schema.json
+++ b/s2-json-schema/schemas/PEBC.PowerEnvelopeLimitType.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/PEBC.PowerEnvelopeLimitType.schema.json",
     "title": "PEBC_PowerEnvelopeLimitType",
+    "type": "string",
     "enum": ["UPPER_LIMIT", "LOWER_LIMIT"],
     "description": "UPPER_LIMIT: Indicating the upper limit of a PEBC.PowerEnvelope (see Clause 7.6.2)\nLOWER_LIMIT: Indicating the lower limit of a PEBC.PowerEnvelope (see Clause 7.6.2)"
 }

--- a/s2-json-schema/schemas/PPBC.PowerSequenceStatus.schema.json
+++ b/s2-json-schema/schemas/PPBC.PowerSequenceStatus.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/PPBC.PowerSequenceStatus.schema.json",
     "title": "PPBC_PowerSequenceStatus",
+    "type": "string",
     "enum": ["NOT_SCHEDULED", "SCHEDULED", "EXECUTING", "INTERRUPTED", "FINISHED", "ABORTED"],
     "description": "NOT_SCHEDULED: No PPBC.PowerSequence within the PPBC.PowerSequenceContainer is scheduled\nSCHEDULED: The selected PPBC.PowerSequence is scheduled to be executed in the future\nEXECUTING: The selected PPBC.PowerSequence is currently being executed\nINTERRUPTED: The selected PPBC.PowerSequence is being executed, but is currently interrupted and will continue afterwards\nFINISHED: The selected PPBC.PowerSequence was executed and finished successfully\nABORTED: The selected PPBC.PowerSequence was aborted by the device and will not continue"
 }

--- a/s2-json-schema/schemas/ReceptionStatusValues.schema.json
+++ b/s2-json-schema/schemas/ReceptionStatusValues.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/ReceptionStatusValues.schema.json",
     "title": "ReceptionStatusValues",
+    "type": "string",
     "enum": ["INVALID_DATA", "INVALID_MESSAGE", "INVALID_CONTENT", "TEMPORARY_ERROR", "PERMANENT_ERROR", "OK"],
     "description": "INVALID_DATA: Message not understood (e.g. not valid JSON, no message_id found). Consequence: Message is ignored, proceed if possible\nINVALID_MESSAGE: Message was not according to schema. Consequence: Message is ignored, proceed if possible\nINVALID_CONTENT: Message contents is invalid (e.g. contains a non-existing ID). Somewhat equivalent to BAD_REQUEST in HTTP.. Consequence: Message is ignored, proceed if possible.\nTEMPORARY_ERROR: Receiver encountered an error. Consequence: Try to send to message again\nPERMANENT_ERROR: Receiver encountered an error which it cannot recover from. Consequence: Disconnect.\nOK: Message processed normally. Consequence: Proceed normally."
 }

--- a/s2-json-schema/schemas/RevokableObjects.schema.json
+++ b/s2-json-schema/schemas/RevokableObjects.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/RevokableObjects.schema.json",
     "title": "RevokableObjects",
+    "type": "string",
     "enum": ["PEBC.PowerConstraints", "PEBC.EnergyConstraint", "PEBC.Instruction", "PPBC.PowerProfileDefinition", "PPBC.ScheduleInstruction", "PPBC.StartInterruptionInstruction", "PPBC.EndInterruptionInstruction", "OMBC.SystemDescription", "OMBC.Instruction", "FRBC.SystemDescription", "FRBC.Instruction", "DDBC.SystemDescription", "DDBC.Instruction"],
     "description": "PEBC.PowerConstraints: Object type PEBC.PowerConstraints\nPEBC.EnergyConstraint: Object type PEBC.EnergyConstraint\nPEBC.Instruction: Object type PEBC.Instruction\nPPBC.PowerProfileDefinition: Object type PPBC.PowerProfileDefinition\nPPBC.ScheduleInstruction: Object type PPBC.ScheduleInstruction\nPPBC.StartInterruptionInstruction: Object type PPBC.StartInterruptionInstruction\nPPBC.EndInterruptionInstruction: Object type PPBC.EndInterruptionInstruction\nOMBC.SystemDescription: Object type OMBC.SystemDescription\nOMBC.Instruction: Object type OMBC.Instruction\nFRBC.SystemDescription: Object type FRBC.SystemDescription\nFRBC.Instruction: Object type FRBC.Instruction\nDDBC.SystemDescription: Object type DDBC.SystemDescription\nDDBC.Instruction: Object type DDBC.Instruction"
 }

--- a/s2-json-schema/schemas/RoleType.schema.json
+++ b/s2-json-schema/schemas/RoleType.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/RoleType.schema.json",
     "title": "RoleType",
+    "type": "string",
     "enum": ["ENERGY_PRODUCER", "ENERGY_CONSUMER", "ENERGY_STORAGE"],
     "description": "ENERGY_PRODUCER: Identifier for RoleType Producer\nENERGY_CONSUMER: Identifier for RoleType Consumer\nENERGY_STORAGE: Identifier for RoleType Storage"
 }

--- a/s2-json-schema/schemas/SessionRequestType.schema.json
+++ b/s2-json-schema/schemas/SessionRequestType.schema.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/flexiblepower/s2-ws-json/main/s2-json-schema/schemas/SessionRequestType.schema.json",
     "title": "SessionRequestType",
+    "type": "string",
     "enum": ["RECONNECT", "TERMINATE"],
     "description": "RECONNECT: Please reconnect the WebSocket session. Once reconnected, it starts from scratch with a handshake.\nTERMINATE: Disconnect the session (client can try to reconnecting with exponential backoff)"
 }


### PR DESCRIPTION
It appears that only one of the enum JSON schemas has the `type` field correctly defined (`s2-json-schema/schemas/Currency.schema.json`), all the other enums do not have the `type` field.

We use the `s2-ws-json` schemas to auto generate C code and the missing `type` fields are causing issues.

Hopefully this is a contribution that you can accept as it may be beneficial to others.